### PR TITLE
Implement persistent theme toggle

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import "../globals.css";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
+import ThemeProvider from "@/components/ThemeProvider";
 import { navItems } from "@/constants/constants";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
@@ -55,9 +56,11 @@ export default async function RootLayout({ children, params }: Props) {
     <html lang={locale}>
       <body suppressHydrationWarning>
         <NextIntlClientProvider messages={messages}>
-          <Header items={navItems} />
-          {children}
-          <Footer />
+          <ThemeProvider>
+            <Header items={navItems} />
+            {children}
+            <Footer />
+          </ThemeProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,26 @@
 @import "tailwindcss/preflight";
 @import "tailwindcss/utilities";
 
+:root {
+  --bg: #e6ddce;
+  --text: #ea4d51;
+  --surface: #e6ddce;
+  --offWhite: #f5f5f5;
+  --neon: #ea4d51;
+  --overlay: rgba(230, 221, 206, 0.6);
+  --overlay-strong: rgba(230, 221, 206, 0.9);
+}
+
+.dark {
+  --bg: #1a1a1a;
+  --text: #e6ddce;
+  --surface: #333333;
+  --offWhite: #aaaaaa;
+  --neon: #ea4d51;
+  --overlay: rgba(51, 51, 51, 0.6);
+  --overlay-strong: rgba(51, 51, 51, 0.9);
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -11,6 +31,39 @@
 }
 
 body {
-  background-color: #e6ddce;
-  color: #ea4d51;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+@layer utilities {
+  .bg-bg {
+    background-color: var(--bg);
+  }
+  .bg-surface {
+    background-color: var(--surface);
+  }
+  .bg-offWhite {
+    background-color: var(--offWhite);
+  }
+  .bg-neon {
+    background-color: var(--neon);
+  }
+  .text-offWhite {
+    color: var(--offWhite);
+  }
+  .border-neon {
+    border-color: var(--neon);
+  }
+  .neon {
+    color: var(--neon);
+  }
+  .shadow-neon-glow {
+    box-shadow: 0 0 10px var(--neon);
+  }
+  .bg-overlay {
+    background-color: var(--overlay);
+  }
+  .bg-overlay-strong {
+    background-color: var(--overlay-strong);
+  }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import type { NavItem } from "@/types/types";
 import { usePathname } from "next/navigation";
 import { Link } from "@/i18n/routing";
 import LanguageSwitcher from "./LanguageSwitcher";
+import ThemeToggle from "./ThemeToggle";
 import { useTranslations } from "next-intl";
 
 interface HeaderProps {
@@ -35,7 +36,10 @@ export default function Header({ items }: HeaderProps) {
             );
           })}
         </div>
-        <LanguageSwitcher />
+        <div className="flex items-center space-x-4">
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
       </nav>
     </header>
   );

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -9,7 +9,7 @@ export default function Logo() {
         width={400}
         height={225}
         priority
-        className="bg-[#E6DDCE]/60"
+        className="bg-overlay"
       />
     </div>
   );

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -21,7 +21,7 @@ export default function Modal({ item, onClose }: Props) {
   }, [onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#e6ddce]/90 px-4">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-overlay-strong px-4">
       <div className="absolute inset-0" onClick={onClose} />
 
       <motion.div
@@ -29,7 +29,7 @@ export default function Modal({ item, onClose }: Props) {
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.9 }}
         transition={{ duration: 0.2 }}
-        className="relative rounded-xl overflow-hidden max-w-lg w-full border-2 bg-[#e6ddce]"
+        className="relative rounded-xl overflow-hidden max-w-lg w-full border-2 bg-surface"
       >
         <div className="relative w-full h-64">
           <Image

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface ThemeContextValue {
+  theme: "light" | "dark";
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored ?? (prefersDark ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,11 @@
+"use client";
+import { useTheme } from "./ThemeProvider";
+
+export default function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  return (
+    <button onClick={toggle} className="text-sm px-2 py-1 border rounded">
+      {theme === "dark" ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -45,7 +45,7 @@ export default function Main() {
         animate={{ opacity: 1 }}
         transition={{ duration: 0.8 }}
       >
-        <div className="bg-[#E6DDCE]/60 pointer-events-none" />
+        <div className="bg-overlay pointer-events-none" />
 
         <AnimatePresence mode="wait">
           <motion.div


### PR DESCRIPTION
## Summary
- add CSS variables for light and dark modes
- create ThemeProvider and ThemeToggle components
- update pages to use new overlay classes
- wrap layout with ThemeProvider and expose toggle in the header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d11470d80832d83eb1c8ed98524b2