### PR TITLE
Add icon toggle for theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sace-dorcol",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "framer-motion": "^12.23.0",
         "next": "15.3.4",
         "next-intl": "^4.3.4",
@@ -276,6 +277,15 @@
       "integrity": "sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==",
       "dependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "framer-motion": "^12.23.0",
     "next": "15.3.4",
     "next-intl": "^4.3.4",

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,11 +1,20 @@
 "use client";
 import { useTheme } from "./ThemeProvider";
+import { SunIcon, MoonIcon } from "@heroicons/react/24/outline";
 
 export default function ThemeToggle() {
   const { theme, toggle } = useTheme();
   return (
-    <button onClick={toggle} className="text-sm px-2 py-1 border rounded">
-      {theme === "dark" ? "Light" : "Dark"}
+    <button
+      onClick={toggle}
+      className="p-2 border rounded cursor-pointer hover:scale-105 transition"
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? (
+        <SunIcon className="w-5 h-5" />
+      ) : (
+        <MoonIcon className="w-5 h-5" />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- add `@heroicons/react` for icons
- show sun/moon icons in theme switcher
- style theme toggle button with pointer and hover effect

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d1e561838832da36972fc2da2874f